### PR TITLE
Fix typo in a log message in ccid_usb.c

### DIFF
--- a/src/ccid_usb.c
+++ b/src/ccid_usb.c
@@ -1313,7 +1313,7 @@ int ccid_check_firmware(struct libusb_device_descriptor *desc)
 		{
 			if (DriverOptions & DRIVER_OPTION_USE_BOGUS_FIRMWARE)
 			{
-				DEBUG_INFO3("Firmware (%X.%02X) is bogus! but you choosed to use it",
+				DEBUG_INFO3("Firmware (%X.%02X) is bogus! but you chose to use it",
 					desc->bcdDevice >> 8, desc->bcdDevice & 0xFF);
 				return FALSE;
 			}


### PR DESCRIPTION
s/choosed/chose/